### PR TITLE
feat: add multi-arch support for pnpm

### DIFF
--- a/.github/workflows/pnpm.yaml
+++ b/.github/workflows/pnpm.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ./pnpm/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             node=${{ matrix.node }}
             pnpm=${{ matrix.pnpm }}
@@ -69,6 +70,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ./pnpm/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             node=${{ matrix.node }}
             pnpm=${{ matrix.pnpm }}
@@ -108,6 +110,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ./pnpm/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             node=${{ matrix.node }}
             pnpm=${{ matrix.pnpm }}
@@ -147,6 +150,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ./pnpm/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             node=${{ matrix.node }}
             pnpm=${{ matrix.pnpm }}
@@ -186,6 +190,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ./pnpm/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             node=${{ matrix.node }}
             pnpm=${{ matrix.pnpm }}


### PR DESCRIPTION
Add support for multi-arch pnpm docker image: linux/amd64 and linux/arm64