### PR TITLE
fix: missing qemu+buildx for pnpm build multi-arch

### DIFF
--- a/.github/workflows/pnpm.yaml
+++ b/.github/workflows/pnpm.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ./pnpm/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             node=${{ matrix.node }}
             pnpm=${{ matrix.pnpm }}
@@ -69,6 +70,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ./pnpm/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             node=${{ matrix.node }}
             pnpm=${{ matrix.pnpm }}
@@ -108,6 +110,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ./pnpm/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             node=${{ matrix.node }}
             pnpm=${{ matrix.pnpm }}
@@ -147,6 +150,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ./pnpm/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             node=${{ matrix.node }}
             pnpm=${{ matrix.pnpm }}
@@ -186,6 +190,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: ./pnpm/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             node=${{ matrix.node }}
             pnpm=${{ matrix.pnpm }}

--- a/.github/workflows/pnpm.yaml
+++ b/.github/workflows/pnpm.yaml
@@ -19,6 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Fix build for https://github.com/Guergeiro/docker-images/pull/8

Docker for multi-arch requires qemu and buildx: https://docs.docker.com/build/ci/github-actions/multi-platform/

